### PR TITLE
Fix streamlit TypeError in course catalogue

### DIFF
--- a/pages/Course_Catalogue.py
+++ b/pages/Course_Catalogue.py
@@ -226,9 +226,10 @@ def extract_courses(text: str, openai_client: OpenAI) -> List[CoursePreview]:
             },
             {"role": "user", "content": text},
         ],
-        response_model=CourseCatalogueResponse,
+        response_format={"type": "json_object"},
     )
-    parsed = response.parse()
+    parsed_json = response.choices[0].message.content
+    parsed = CourseCatalogueResponse.model_validate_json(parsed_json)
     return parsed.courses
 
 def extract_course_details(course_name: str, text: str, openai_client: OpenAI) -> CourseDetail:
@@ -272,9 +273,10 @@ def extract_course_details(course_name: str, text: str, openai_client: OpenAI) -
             },
             {"role": "user", "content": f"Course Name: {course_name}\n{text}"},
         ],
-        response_model=CourseDetailResponse,
+        response_format={"type": "json_object"},
     )
-    parsed = response.parse()
+    parsed_json = response.choices[0].message.content
+    parsed = CourseDetailResponse.model_validate_json(parsed_json)
     return parsed.course_detail
 
 def search_duckduckgo(query: str) -> str:


### PR DESCRIPTION
## Summary
- adjust OpenAI calls in `Course_Catalogue.py` to use JSON output
- parse results with Pydantic models
- this resolves TypeError from unsupported `response_model` parameter

Codex was used to run linters and tests. It reported lint warnings and test failures due to missing packages in the environment. Manual dependency installation was attempted but blocked, so tests could not complete.


------
https://chatgpt.com/codex/tasks/task_e_6888a7d30e68832890ea170da37162fa