### PR TITLE
Fix Outreach template company placeholder

### DIFF
--- a/pages/3_Outreach.py
+++ b/pages/3_Outreach.py
@@ -68,9 +68,9 @@ templates = {
     "Custom": "",
     "Template 1": (
         "Dear Dr/Professor [NAME],\n"
-        "I hope this message finds you well. I’m writing to ask if we could arrange to meet during the [CONFERENCE NAME] conference in late [DATE]? I’ll be in [CITY] and would love to offer you a coffee or to meet at the Sage stand for a quick discussion about a new textbook idea.\n\n"
-        "I am the [TOPIC] editor here at Sage and would find it invaluable to have an opportunity to discuss your teaching of (and research interests in) [TOPIC]. I appreciate a textbook may (or may not…) be something you have considered working on in the near future, but I’d also love a quick, open and exploratory discussion about texts, your experience using existing books, and an idea I have for a new textbook in a little more detail.\n\n"
-        "I’d be delighted if we could meet at the Sage stand during [CONFERENCE NAME]. Looking at my diary, I could meet any time between [TIME] on [DAY], [MONTH] and [TIME] on [DAY], [MONTH]. I hope we might have chance to meet at the [CONFERENCE NAME], and look forward to hearing from you.\n\n"
+        "I hope this message finds you well. I’m writing to ask if we could arrange to meet during the [CONFERENCE NAME] conference in late [DATE]? I’ll be in [CITY] and would love to offer you a coffee or to meet at the [COMPANY] stand for a quick discussion about a new textbook idea.\n\n"
+        "I am the [TOPIC] editor here at [COMPANY] and would find it invaluable to have an opportunity to discuss your teaching of (and research interests in) [TOPIC]. I appreciate a textbook may (or may not…) be something you have considered working on in the near future, but I’d also love a quick, open and exploratory discussion about texts, your experience using existing books, and an idea I have for a new textbook in a little more detail.\n\n"
+        "I’d be delighted if we could meet at the [COMPANY] stand during [CONFERENCE NAME]. Looking at my diary, I could meet any time between [TIME] on [DAY], [MONTH] and [TIME] on [DAY], [MONTH]. I hope we might have chance to meet at the [CONFERENCE NAME], and look forward to hearing from you.\n\n"
         "With best wishes,\n\n[YOUR NAME]"
     ),
 }


### PR DESCRIPTION
## Summary
- replace direct company name with `[COMPANY]` in the Outreach template

Codex was used to modify the Streamlit email template in `pages/3_Outreach.py`. The tool executed `make lint` and `make test` to honor project guidelines. Linting failed due to existing style issues and tests failed because required dependencies like pandas could not be installed without internet access.


------
https://chatgpt.com/codex/tasks/task_e_68892031365083288df74424ddd64ec6